### PR TITLE
Disable and Re-enable Foreign Key Check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
+before_install:
+- travis_retry gem install bundler -v 1.7
 rvm:
   - 1.9.3
   - 2.1.2

--- a/lib/activerecord-mysql-structure/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-structure/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
@@ -11,7 +11,7 @@ module ActiveRecord
           sql = "SHOW TABLES"
         end
 
-        structure = "/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */\n"
+        structure = "/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;\n\n"
 
         structure += select_all(sql).map { |table|
           table.delete('Table_type')
@@ -19,7 +19,7 @@ module ActiveRecord
           "DROP TABLE IF EXISTS #{quote_table_name(table.to_a.first.last)};\n\n" + exec_query(sql).first['Create Table'] + ";\n\n" # CHANGE 1 of 2 FROM RAILS
         }.join.gsub(/\s+AUTO_INCREMENT=\d+\s+/, ' ') # CHANGE 2 of 2 FROM RAILS
 
-        structure += "/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */\n"
+        structure += "/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;\n\n"
 
         structure
       end

--- a/lib/activerecord-mysql-structure/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
+++ b/lib/activerecord-mysql-structure/active_record/v3/connection_adapters/abstract_mysql_adapter.rb
@@ -3,24 +3,23 @@ require 'active_record/connection_adapters/abstract_mysql_adapter'
 module ActiveRecord
   module ConnectionAdapters
     class AbstractMysqlAdapter < AbstractAdapter
-      # Override this to add DROP TABLE IF EXISTS statements to each CREATE TABLE
+      # Override this to disable FOREIGN_KEY_CHECK at the start of the structure file
+      # and re-enable it at the end and to add DROP TABLE IF EXISTS statements to each CREATE TABLE
       def structure_dump #:nodoc:
         if supports_views?
           sql = "SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'"
         else
           sql = "SHOW TABLES"
         end
-
+        # https://lists.mysql.com/announce/166
+        # only disable FOREIGN_KEY_CHECK when mysql version is 4.0.14 or later
         structure = "/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;\n\n"
-
         structure += select_all(sql).map { |table|
           table.delete('Table_type')
           sql = "SHOW CREATE TABLE #{quote_table_name(table.to_a.first.last)}"
           "DROP TABLE IF EXISTS #{quote_table_name(table.to_a.first.last)};\n\n" + exec_query(sql).first['Create Table'] + ";\n\n" # CHANGE 1 of 2 FROM RAILS
         }.join.gsub(/\s+AUTO_INCREMENT=\d+\s+/, ' ') # CHANGE 2 of 2 FROM RAILS
-
         structure += "/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;\n\n"
-
         structure
       end
 

--- a/lib/activerecord-mysql-structure/version.rb
+++ b/lib/activerecord-mysql-structure/version.rb
@@ -1,7 +1,7 @@
 module ActiveRecord
   module Mysql
     module Structure
-      VERSION = '0.0.2'
+      VERSION = '0.0.3'
     end
   end
 end

--- a/spec/activerecord/mysql/structure_spec.rb
+++ b/spec/activerecord/mysql/structure_spec.rb
@@ -26,6 +26,14 @@ describe ActiveRecord::Mysql::Structure do
         }]
       end
 
+      it 'starts with FOREIGN_KEY_CHECKS disable' do
+        expect(adapter.structure_dump.lines.to_a[0]).to eq "/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;\n"
+      end
+
+      it 'includes FOREIGN_KEY_CHECKS re-enable at the end' do
+        expect(adapter.structure_dump.lines.to_a[-2]).to eq "/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;\n"
+      end
+
       it 'adds DROP TABLE IF EXISTS statements' do
         expect(adapter.structure_dump).to include 'DROP TABLE IF EXISTS `foobar`'
       end


### PR DESCRIPTION
`structure.sql` is currently in alphabetical order by table name, not in topological-sort order by foreign key reference.

The problem with this is when a table reference to another table that is created later in the order, the latter table is undefined at the moment. This is fixed in rails 4.0 (according to @alisdair and https://github.com/PagerDuty/activerecord-mysql-structure/pull/3/files#diff-ec75dbbe5c16c6f075daefb1802563c9R14)

An easier approach would be how rails 4.0+ generate `structure.sql`: disable `FOREIGN_KEY_CHECKS` at the start of the structure.sql file, and re-enable it at the end.
```
/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;

DROP TABLE IF EXISTS `movies_theaters`;

CREATE TABLE `movies_theaters` (
 ...
  CONSTRAINT `movies_theaters_theater_id_fk` FOREIGN KEY (`theater_id`) REFERENCES `theaters` (`id`) ON DELETE CASCADE
);

DROP TABLE IF EXISTS `theaters`;

CREATE TABLE `theaters` (
...
);
...
/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

INSERT INTO schema_migrations (version) VALUES ('20090220200555');
...
```
