### PR TITLE
Update for rails 4 and beyond!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
   - 2.4
   - 2.5
   - 2.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: ruby
 rvm:
-  - 1.9.3
-  - 2.1.2
-  - 2.1
   - 2.2
   - 2.3
   - 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,18 @@ rvm:
   - 1.9.3
   - 2.1.2
   - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
+  - 2.6
 env:
   - "RAILS_VERSION=3.2.22.5"
   - "RAILS_VERSION=4.2.9"
+  - "RAILS_VERSION=5.2.2"
 cache:
   bundler: true
 install:
   - gem update --system
   - gem install bundler
   - bundle install --jobs=3 --retry=3
-branches:
-  only:
-    - master

--- a/activerecord-mysql-structure.gemspec
+++ b/activerecord-mysql-structure.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
-  spec.add_runtime_dependency 'activerecord', '>= 3.2', '<= 5.0'
+  spec.add_runtime_dependency 'activerecord', '>= 3.2', '< 6.0'
 end

--- a/activerecord-mysql-structure.gemspec
+++ b/activerecord-mysql-structure.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 


### PR DESCRIPTION
The previous commit did extend out the versioning. However, there are minor versions in rails 5 now that we should also support.

In addition, the testing should include this new version.

In addition, this deprecates testing ruby versions that are EOL'ed.